### PR TITLE
Fixes drawing preview lines to already completed waypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A mod that enhances the gamemaster mode with several tools and QoL improvements:
 
 
 ## Contributors
-Kex  
 Crowdedlight  
+Kex  
+
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # OdinGameMasterAdditions
+
+A mod that enhances the gamemaster mode with several tools and QoL improvements:
+
+## Features
+
+- Delete All Dead, on a right-click context action to easily delete all dead bodies/units. Makes it easy to clean up.
+
+- Enable Damage, is toggled in the attributes on units/player. Handy to make gamemaster player immortal to avoid getting randomly shot by AI and have to reset radios. 
+
+- Stance attribute for the AI groups so you can control their stance
+
+- Formation attribute for the AI groups to control the formation the AI will move in. 
+
+- Skill attribute for the AI groups. You can control the AI skill level. 
+
+- Cycle Waypoint, you can now add the familiar cycle waypoint to make AI move in repeated patterns
+
+
+## Contributors
+Kex  
+Crowdedlight  
+

--- a/Scripts/Game/Editor/Components/EditableEntity/Modded/SCR_EditableGroupComponent.c
+++ b/Scripts/Game/Editor/Components/EditableEntity/Modded/SCR_EditableGroupComponent.c
@@ -7,18 +7,21 @@ modded class SCR_EditableGroupComponent : SCR_EditableEntityComponent
 	{
 		//--- Delete waypoints which were not assigned to another group
 		SCR_EditableWaypointComponent waypointCompToRemove = SCR_EditableWaypointComponent.Cast(SCR_EditableEntityComponent.GetEditableEntity(wp));
-		
+			
 		if (waypointCompToRemove && waypointCompToRemove.GetParentEntity() == this)
 		{
 			// Only delete if there is no waypoint cycle present
 			bool has_cycle = false;
 			array<AIWaypoint> waypoints = {};
 			m_Group.GetWaypoints(waypoints);
+			
 			foreach (AIWaypoint waypoint: waypoints)
 			{
+				
 				if (AIWaypointCycle.Cast(waypoint))
 				{
 					has_cycle = true;
+					waypointCompToRemove.setCompleted();
 					break;
 				};
 			};
@@ -26,6 +29,17 @@ modded class SCR_EditableGroupComponent : SCR_EditableEntityComponent
 			{
 				waypointCompToRemove.Delete();
 			}
+		}
+		ReindexWaypoints();
+	}
+	
+	override protected void OnWaypointAdded(AIWaypoint wp)
+	{
+		SCR_EditableWaypointComponent waypoint = SCR_EditableWaypointComponent.Cast(SCR_EditableEntityComponent.GetEditableEntity(wp));
+		if (waypoint)
+		{
+			waypoint.setCompleted(false);
+			waypoint.SetParentEntity(this);
 		}
 		ReindexWaypoints();
 	}

--- a/Scripts/Game/Editor/Components/EditableEntity/Modded/SCR_EditableWaypointComponent.c
+++ b/Scripts/Game/Editor/Components/EditableEntity/Modded/SCR_EditableWaypointComponent.c
@@ -1,0 +1,30 @@
+/*!
+Special configuration for editable waypoint.
+*/
+
+modded class SCR_EditableWaypointComponent : SCR_EditableEntityComponent
+{	
+	[RplProp()]
+	protected bool m_bCompleted = false;
+	
+	/*!
+	Check if the waypoint has been completed. Can be nessecary for cycle behaviour.
+	\return True if completed
+	*/
+	bool IsCompleted()
+	{
+		return m_bCompleted;
+	}
+	
+	/*!
+	Set waypoint as completed. Can be nessecary for cycle behaviour.
+	\param explicit set completed status
+	*/
+	void setCompleted(bool completed = true)
+	{
+		if (completed)
+			m_bCompleted = true;
+		else 
+			m_bCompleted = false;
+	}
+}

--- a/Scripts/Game/Editor/UI/Components/EditableEntityFilters/Modded/SCR_WaypointLinesEditorUIComponent.c
+++ b/Scripts/Game/Editor/UI/Components/EditableEntityFilters/Modded/SCR_WaypointLinesEditorUIComponent.c
@@ -1,0 +1,42 @@
+/*!
+Special configuration for drawing waypoint lines that supports cycle waypoint
+*/
+modded class SCR_WaypointLinesEditorUIComponent: SCR_BaseEditorUIComponent
+{	
+	override protected void OnMenuUpdate(float timeSlice)
+	{
+		SCR_EditableEntityComponent child, prevWaypoint;
+		SCR_EditableWaypointComponent waypoint;
+		vector points[2];
+		vector pos1, pos2;
+		foreach (SCR_EditableEntityComponent group, int groupTokens: m_Groups)
+		{
+			if (!group)
+				continue;
+					
+			for (int i = 0, count = group.GetChildrenCount(true); i < count; i++)
+			{
+				child = group.GetChild(i);
+				if (child.GetEntityType() != EEditableEntityType.WAYPOINT)
+					continue;
+				
+				waypoint = SCR_EditableWaypointComponent.Cast(child);
+				prevWaypoint = waypoint.GetPrevWaypoint();
+								
+				// don't draw lines if the waypoint have been completed. Can happen when using cycle waypoint		
+				if (!waypoint.GetPos(pos1) || !prevWaypoint.GetPos(pos2) || waypoint.IsCompleted())
+					continue;
+				
+				points = {pos1, pos2};
+				Shape.CreateLines(m_iLineColorPacked, m_ShapeFlags, points, 2);
+			}
+			
+		}
+		
+#ifdef WAYPOINT_LINES_DEBUG
+		DbgUI.Begin("");
+		DbgUI.Text(m_Groups.Count().ToString());
+		DbgUI.End();
+#endif
+	}
+};


### PR DESCRIPTION
**This PR fixes the following:** 

- Updating the readme. (Should probably be moved to its own PR)
- When using the cycle waypoint the already completed waypoints will continue to draw a preview line to the group. This PR adds a new member variable to waypoints that designates if the waypoint has been "completed" and stops it from drawing lines to completed waypoints. 
![image](https://user-images.githubusercontent.com/7889925/172028827-d431cca1-4525-4373-bf0f-afe639d7a203.png)

**OBS: Seems like these lines are only drawn on server and not for all game masters on dedicated servers. So while the fix works, it doesn't really have an impact until BI fixes the line drawing**