### PR TITLE
Toggle damage refactor and character fix

### DIFF
--- a/Configs/Editor/AttributeLists/Edit.conf
+++ b/Configs/Editor/AttributeLists/Edit.conf
@@ -8,6 +8,13 @@ SCR_EditorAttributeList {
    m_CategoryConfig "{8A757725BEAC5B36}Configs/Editor/AttributeCategories/Character.conf"
    m_Layout "{D0F3CE0C63A5AEBB}UI/layouts/Editor/Attributes/AttributePrefabs/AttributePrefab_Checkbox.layout"
   }
+  ODIN_ToggleDamageVehicleAttribute "{5DB0F3FD83111076}" {
+   m_UIInfo SCR_EditorAttributeUIInfo "{5DB0F3FD8108C6AB}" {
+    Name "#ODIN-Editor_Attribute_EnableDamage_Name"
+   }
+   m_CategoryConfig "{7FA3F309CBFCDACF}Configs/Editor/AttributeCategories/Vehicle.conf"
+   m_Layout "{D0F3CE0C63A5AEBB}UI/layouts/Editor/Attributes/AttributePrefabs/AttributePrefab_Checkbox.layout"
+  }
   ODIN_ToggleVisibilityEditorAttribute "{5D955C21A940FB32}" {
    m_UIInfo SCR_EditorAttributeUIInfo "{5D955C21B533D246}" {
     Name "#ODIN-Editor_Attribute_VisibilityToggle_Name"

--- a/Scripts/Game/ODIN/Editor/Containers/Attributes/ODIN_ToggleDamageEditorAttribute.c
+++ b/Scripts/Game/ODIN/Editor/Containers/Attributes/ODIN_ToggleDamageEditorAttribute.c
@@ -15,7 +15,7 @@ class ODIN_ToggleDamageEditorAttribute : SCR_BaseEditorAttribute
 		if (!owner) 
 			return null;
 		
-		if (Vehicle.Cast(owner))
+		if (!SCR_ChimeraCharacter.Cast(owner))
 			return null;
 		
 		ScriptedDamageManagerComponent damageComponent = ScriptedDamageManagerComponent.Cast(owner.FindComponent(ScriptedDamageManagerComponent));

--- a/Scripts/Game/ODIN/Editor/Containers/Attributes/ODIN_ToggleDamageVehicleAttribute.c
+++ b/Scripts/Game/ODIN/Editor/Containers/Attributes/ODIN_ToggleDamageVehicleAttribute.c
@@ -15,7 +15,7 @@ class ODIN_ToggleDamageVehicleAttribute : SCR_BaseEditorAttribute
 		if (!owner) 
 			return null;
 		
-		if (SCR_ChimeraCharacter.Cast(owner))
+		if (!Vehicle.Cast(owner))
 			return null;
 		
 		DamageManagerComponent damageComponent = DamageManagerComponent.Cast(owner.FindComponent(DamageManagerComponent));

--- a/Scripts/Game/ODIN/Editor/Containers/Attributes/ODIN_ToggleDamageVehicleAttribute.c
+++ b/Scripts/Game/ODIN/Editor/Containers/Attributes/ODIN_ToggleDamageVehicleAttribute.c
@@ -2,7 +2,7 @@
 Entity Attribute for toggle damage on unit
 */
 [BaseContainerProps(), SCR_BaseEditorAttributeCustomTitle()]
-class ODIN_ToggleDamageEditorAttribute : SCR_BaseEditorAttribute
+class ODIN_ToggleDamageVehicleAttribute : SCR_BaseEditorAttribute
 {
 	override SCR_BaseEditorAttributeVar ReadVariable(Managed item, SCR_AttributesManagerEditorComponent manager)
 	{
@@ -15,14 +15,15 @@ class ODIN_ToggleDamageEditorAttribute : SCR_BaseEditorAttribute
 		if (!owner) 
 			return null;
 		
-		if (Vehicle.Cast(owner))
+		if (SCR_ChimeraCharacter.Cast(owner))
 			return null;
 		
-		ScriptedDamageManagerComponent damageComponent = ScriptedDamageManagerComponent.Cast(owner.FindComponent(ScriptedDamageManagerComponent));
+		DamageManagerComponent damageComponent = DamageManagerComponent.Cast(owner.FindComponent(DamageManagerComponent));
+		
 		if (!damageComponent) 
 			return null;
 		
-		return SCR_BaseEditorAttributeVar.CreateBool(damageComponent.ODIN_IsDamageEnabled());		
+		return SCR_BaseEditorAttributeVar.CreateBool(damageComponent.IsDamageHandlingEnabled());		
 	}
 	override void WriteVariable(Managed item, SCR_BaseEditorAttributeVar var, SCR_AttributesManagerEditorComponent manager, int playerID)
 	{
@@ -35,11 +36,11 @@ class ODIN_ToggleDamageEditorAttribute : SCR_BaseEditorAttribute
 		if (!owner) 
 			return;
 		
-		// todo, move it to helper when verified it works 
-		ScriptedDamageManagerComponent damageComponent = ScriptedDamageManagerComponent.Cast(owner.FindComponent(ScriptedDamageManagerComponent));
+		DamageManagerComponent damageComponent = DamageManagerComponent.Cast(owner.FindComponent(DamageManagerComponent));
 		if (!damageComponent) 
 			return;
-		
-		damageComponent.ODIN_SetDamageEnabled(var.GetBool());;
+			
+		// toggle damage handling 
+		damageComponent.EnableDamageHandling(var.GetBool());
 	}
 };

--- a/Scripts/GameCode/ODIN/Components/ScriptedDamageManagerComponent.c
+++ b/Scripts/GameCode/ODIN/Components/ScriptedDamageManagerComponent.c
@@ -12,21 +12,21 @@ modded class ScriptedDamageManagerComponent : BaseScriptedDamageManagerComponent
 	void ODIN_SetDamageEnabled(bool enabled)
 	{
 		m_bODIN_isDamageEnabled = enabled;
-		this.ODIN_OnEnableDamageValueUpdated();
+		ODIN_OnEnableDamageValueUpdated();
 	}
 	
 	void ODIN_OnEnableDamageValueUpdated()
 	{
 		// add function to invoker if damage is disabled
 		if (!m_bODIN_isDamageEnabled)
-			this.GetOnDamage().Insert(this.ODIN_disableDamage);
+			GetOnDamage().Insert(ODIN_disableDamage);
 		else
-			this.GetOnDamage().Remove(this.ODIN_disableDamage);
+			GetOnDamage().Remove(ODIN_disableDamage);
 	}
 	
 	void ODIN_disableDamage(EDamageType type, float damage, HitZone pHitZone, IEntity instigator, inout vector outMat[3], float speed, int colliderID, int nodeID)
 	{
-		ChimeraCharacter char = ChimeraCharacter.Cast(this.GetOwner());
+		ChimeraCharacter char = ChimeraCharacter.Cast(GetOwner());
 		// null check might not be needed as this lives inside the ScriptedDamageManager component, and as such a char should always be "connected"
 		if (!char)
 			return;

--- a/Scripts/GameCode/ODIN/Components/ScriptedDamageManagerComponent.c
+++ b/Scripts/GameCode/ODIN/Components/ScriptedDamageManagerComponent.c
@@ -2,7 +2,6 @@
 //------------------------------------------------------------------------------------------------
 modded class ScriptedDamageManagerComponent : BaseScriptedDamageManagerComponent
 {
-	[RplProp(onRplName: "ODIN_OnEnableDamageValueUpdated")]
 	protected bool m_bODIN_isDamageEnabled = true;
 	
 	bool ODIN_IsDamageEnabled()
@@ -13,7 +12,6 @@ modded class ScriptedDamageManagerComponent : BaseScriptedDamageManagerComponent
 	void ODIN_SetDamageEnabled(bool enabled)
 	{
 		m_bODIN_isDamageEnabled = enabled;
-		Replication.BumpMe();
 		this.ODIN_OnEnableDamageValueUpdated();
 	}
 	

--- a/Scripts/GameCode/ODIN/Components/ScriptedDamageManagerComponent.c
+++ b/Scripts/GameCode/ODIN/Components/ScriptedDamageManagerComponent.c
@@ -13,18 +13,16 @@ modded class ScriptedDamageManagerComponent : BaseScriptedDamageManagerComponent
 	void ODIN_SetDamageEnabled(bool enabled)
 	{
 		m_bODIN_isDamageEnabled = enabled;
-		Print(m_bODIN_isDamageEnabled);
 		Replication.BumpMe();
 		this.ODIN_OnEnableDamageValueUpdated();
 	}
 	
 	void ODIN_OnEnableDamageValueUpdated()
 	{
-		Print("value update");
 		// add function to invoker if damage is disabled
 		if (!m_bODIN_isDamageEnabled)
 			this.GetOnDamage().Insert(this.ODIN_disableDamage);
-		else // What happens if we try to remove and it never was added?
+		else
 			this.GetOnDamage().Remove(this.ODIN_disableDamage);
 	}
 	

--- a/Scripts/GameCode/ODIN/Components/ScriptedDamageManagerComponent.c
+++ b/Scripts/GameCode/ODIN/Components/ScriptedDamageManagerComponent.c
@@ -1,0 +1,44 @@
+
+//------------------------------------------------------------------------------------------------
+modded class ScriptedDamageManagerComponent : BaseScriptedDamageManagerComponent
+{
+	[RplProp(onRplName: "ODIN_OnEnableDamageValueUpdated")]
+	protected bool m_bODIN_isDamageEnabled = true;
+	
+	bool ODIN_IsDamageEnabled()
+	{
+		return m_bODIN_isDamageEnabled;
+	}
+	
+	void ODIN_SetDamageEnabled(bool enabled)
+	{
+		m_bODIN_isDamageEnabled = enabled;
+		Print(m_bODIN_isDamageEnabled);
+		Replication.BumpMe();
+		this.ODIN_OnEnableDamageValueUpdated();
+	}
+	
+	void ODIN_OnEnableDamageValueUpdated()
+	{
+		Print("value update");
+		// add function to invoker if damage is disabled
+		if (!m_bODIN_isDamageEnabled)
+			this.GetOnDamage().Insert(this.ODIN_disableDamage);
+		else // What happens if we try to remove and it never was added?
+			this.GetOnDamage().Remove(this.ODIN_disableDamage);
+	}
+	
+	void ODIN_disableDamage(EDamageType type, float damage, HitZone pHitZone, IEntity instigator, inout vector outMat[3], float speed, int colliderID, int nodeID)
+	{
+		ChimeraCharacter char = ChimeraCharacter.Cast(this.GetOwner());
+		// null check might not be needed as this lives inside the ScriptedDamageManager component, and as such a char should always be "connected"
+		if (!char)
+			return;
+		// do full heal 
+		SCR_CharacterDamageManagerComponent dmgComponent = SCR_CharacterDamageManagerComponent.Cast(char.FindComponent(SCR_CharacterDamageManagerComponent));		
+		if (!dmgComponent)
+			return;
+		
+		dmgComponent.FullHeal();
+	}	
+};


### PR DESCRIPTION
Does the following:

- Moves the vehicle toggle damage attribute into the vehicle category
- Redone the Character damage disable. Engine method doesn't work. Is now doing full heal on any damage, and thus you can't die to guns or fall damage

So the vehicle is still using the engine method and original way, as that seems to work. Only the characters are changed to our hack-around, until engine methods works again. 

Tested with a single peer

Although when getting shot repeatable you still flinch and get the blurry effect. The blurry effect seems to recover rather quickly though. But it does mean you have instances where this is what you see.
![billede](https://github.com/ArmaOdinDevs/OdinGameMasterAdditions/assets/7889925/6a8635b7-5ea0-44a7-a5d9-bf85150c3794)
