### PR TITLE
workbench plugin for script editor shortcuts: comment in/out lines and move lines up and down

### DIFF
--- a/Scripts/WorkbenchGame/ODIN/ScriptEditor/ODIN_CommentPlugin.c
+++ b/Scripts/WorkbenchGame/ODIN/ScriptEditor/ODIN_CommentPlugin.c
@@ -1,0 +1,52 @@
+
+[WorkbenchPluginAttribute(name: "Code Comment Plugin", description: "Comments or uncomments code in script editor", shortcut: "ctrl+/", wbModules: { "ScriptEditor" }, awesomeFontCode: 0xF121)]
+class ODIN_CommentPlugin : WorkbenchPlugin
+{
+	
+	// It doesn't seem like workbench plugins support setting shortcut based on settings, as shortcut can't be changed inside function and attribute can not take a member variable 
+	// There seems to be no support from ScriptEditor to be able to get the current selected lines. So no way of applying commenting to multiple lines. 
+	// There seems to be no support for managing ctrl+z behaviour, and because we replace/set a line, it seems like a single ctrl+z removes the line completely and it takes a second ctrl+z to go back to the string before
+	
+	// There doesn't seem to be a way to "load" plugins created other than having it in the workbench folder... so need to add the plugin to the mod... less than ideal and seems counter-intuative for a dev "plugin"
+	
+	override void Run()
+	{		
+		ScriptEditor scriptEditor = Workbench.GetModule(ScriptEditor);		
+		
+		// Check if current line starts with //, then we remove it, otherwise we add it		
+		string lineContent;
+		scriptEditor.GetLineText(lineContent);
+	
+		// trimming the line to trim whitespace to test if first text of line is // and thus a comment
+		string trimmedLine = lineContent.Trim();
+		
+		if (trimmedLine.StartsWith("//"))
+		{
+			// remove first //
+			int index = lineContent.IndexOf("//");
+			int indexEnd = lineContent.Length();
+			
+			// As we remove // its -2 at end index
+			int indexDiff = indexEnd - index - 2;
+			
+			// safety check to avoid out-of-bounds substring call
+			if ((indexDiff + index + 2) > indexEnd)
+			{
+				Print("ERROR in CommentPlugin. Tried to access index bigger than text line");
+				return;
+			}
+			
+			// part 1 is spaces/indents until we hit first //
+			string part1 = lineContent.Substring(0, index);
+			// part2 is from index of // to end. 
+			string part2 = lineContent.Substring(index+2, indexDiff);
+
+			lineContent = part1 + part2;
+		} else 
+		{
+			// we want to comment, for now ignore indent and comment at first line
+			lineContent = "//" + lineContent;
+		}		
+		scriptEditor.SetLineText(lineContent);
+	}
+}

--- a/Scripts/WorkbenchGame/ODIN/ScriptEditor/ODIN_DeIndentPlugin.c
+++ b/Scripts/WorkbenchGame/ODIN/ScriptEditor/ODIN_DeIndentPlugin.c
@@ -1,0 +1,20 @@
+
+[WorkbenchPluginAttribute(name: "Deindent Line Plugin", description: "Deindent current line in script editor", shortcut: "shift+tab", wbModules: { "ScriptEditor" }, awesomeFontCode: 0xF121)]
+class ODIN_DeIndentPlugin : WorkbenchPlugin
+{
+	override void Run()
+	{		
+		ScriptEditor scriptEditor = Workbench.GetModule(ScriptEditor);		
+				
+		// get line above line
+		string lineContent;
+		scriptEditor.GetLineText(lineContent);
+		
+		// check if first characters are tabs
+		if (lineContent.StartsWith("\t"))
+		{
+			lineContent = lineContent.Substring(1,lineContent.Length()-1); 
+			scriptEditor.SetLineText(lineContent);
+		}
+	}
+}

--- a/Scripts/WorkbenchGame/ODIN/ScriptEditor/ODIN_DetentPlugin.c
+++ b/Scripts/WorkbenchGame/ODIN/ScriptEditor/ODIN_DetentPlugin.c
@@ -1,6 +1,6 @@
 
-[WorkbenchPluginAttribute(name: "Deindent Line Plugin", description: "Deindent current line in script editor", shortcut: "shift+tab", wbModules: { "ScriptEditor" }, awesomeFontCode: 0xF121)]
-class ODIN_DeIndentPlugin : WorkbenchPlugin
+[WorkbenchPluginAttribute(name: "Detent Line Plugin", description: "Detent current line in script editor", shortcut: "shift+tab", wbModules: { "ScriptEditor" }, awesomeFontCode: 0xF121)]
+class ODIN_DetentPlugin : WorkbenchPlugin
 {
 	override void Run()
 	{		
@@ -15,6 +15,6 @@ class ODIN_DeIndentPlugin : WorkbenchPlugin
 		{
 			lineContent = lineContent.Substring(1,lineContent.Length()-1); 
 			scriptEditor.SetLineText(lineContent);
-		}
+		}	
 	}
 }

--- a/Scripts/WorkbenchGame/ODIN/ScriptEditor/ODIN_MoveLinePlugin.c
+++ b/Scripts/WorkbenchGame/ODIN/ScriptEditor/ODIN_MoveLinePlugin.c
@@ -38,7 +38,7 @@ class ODIN_MoveLineDownPlugin : WorkbenchPlugin
 		int totalLines = scriptEditor.GetLinesCount();
 		int currentLine = scriptEditor.GetCurrentLine();
 		
-		if (currentLine <= 0 || currentLine >= totalLines-1)
+		if (currentLine < 0 || currentLine >= totalLines-1)
 			return;
 				
 		// get line below

--- a/Scripts/WorkbenchGame/ODIN/ScriptEditor/ODIN_MoveLinePlugin.c
+++ b/Scripts/WorkbenchGame/ODIN/ScriptEditor/ODIN_MoveLinePlugin.c
@@ -1,0 +1,55 @@
+
+[WorkbenchPluginAttribute(name: "Move Line Up Plugin", description: "Move line up with ctrl+shift+up in script editor", shortcut: "ctrl+shift+up", wbModules: { "ScriptEditor" }, awesomeFontCode: 0xF121)]
+class ODIN_MoveLineUpPlugin : WorkbenchPlugin
+{
+	override void Run()
+	{		
+		ScriptEditor scriptEditor = Workbench.GetModule(ScriptEditor);		
+		
+		// if line index is 0, return as we can't move it further up
+		int totalLines = scriptEditor.GetLinesCount();
+		int currentLine = scriptEditor.GetCurrentLine();
+		
+		// due to limitations in engine methods we can't handle up nor down if we are on the very last line... (i.e. missing "insert after" method)
+		if (currentLine <= 0 || currentLine >= totalLines-1)
+			return;
+				
+		// get line above line
+		string lineContent;
+		scriptEditor.GetLineText(lineContent, currentLine-1);
+		
+		// we need to not touch current line, to keep curser. So we are deleting line above and putting it below us. 
+		// insert below us first, to not mess up the indexing for insert
+		scriptEditor.InsertLine(lineContent, currentLine+1);
+		
+		// remove line above 
+		scriptEditor.RemoveLine(currentLine-1);
+	}
+}
+
+[WorkbenchPluginAttribute(name: "Move Line Down Plugin", description: "Move line down with ctrl+shift+down in script editor", shortcut: "ctrl+shift+down", wbModules: { "ScriptEditor" }, awesomeFontCode: 0xF121)]
+class ODIN_MoveLineDownPlugin : WorkbenchPlugin
+{
+	override void Run()
+	{		
+		ScriptEditor scriptEditor = Workbench.GetModule(ScriptEditor);		
+		
+		// if line index is 0, return as we can't move it further up
+		int totalLines = scriptEditor.GetLinesCount();
+		int currentLine = scriptEditor.GetCurrentLine();
+		
+		if (currentLine <= 0 || currentLine >= totalLines-1)
+			return;
+				
+		// get line below
+		string lineContent;
+		scriptEditor.GetLineText(lineContent, currentLine+1);
+		
+		// we need to not touch current line, to keep curser. So we are deleting line below and putting it above us. 
+		// remove line below 
+		scriptEditor.RemoveLine(currentLine+1);
+		
+		// insert that line below us
+		scriptEditor.InsertLine(lineContent, currentLine);
+	}
+}


### PR DESCRIPTION
A plugin made that comments in/out the current line with shortcut. Using the default shortcut of Jetbrains IDEs of ctrl+/. 
Its rather limited due to workbench limitations (see points below). 

Ideally it would not make sense to include it in this mod, but have it as a standalone mod that we could "load" in our workbench for the dev functionality. But from what I can see that is not possible... It has to be present in the workbench files under script. And thus be present in the current mod, or otherwise loaded into the workbench somehow. (Their plugin documentation doesn't seem to cover this). 

A few points:

- It doesn't seem like workbench plugins support setting shortcut based on settings, as shortcut can't be changed inside function and attribute can not take a member variable... So not possible to allow to set your own custom shortcut preference without changing in the plugin source-code.   
- There seems to be no support from ScriptEditor to be able to get the current selected/marked lines. So no way of applying commenting to multiple lines.   
- There seems to be no support for managing ctrl+z behaviour, and because we replace/set a line, it seems like a single ctrl+z removes the line completely and it takes a second ctrl+z to go back to the string before	    

Seems it takes the function of "removing current line", "pasting new line" as two actions when using ``scriptEditor.SetLineText(lineContent);`` instead of a single operation. And there seems to be no other ways of directly modify existing line, other than a full replacement call. 
