### PR TITLE
Fixes the issue that some attributes are not shown

### DIFF
--- a/Configs/Editor/AttributeLists/Edit.conf
+++ b/Configs/Editor/AttributeLists/Edit.conf
@@ -1,4 +1,4 @@
-SCR_EditorAttributeList {
+SCR_EditorAttributeList : "{F3D6C6D25642352C}Configs/Editor/AttributeLists/Edit.conf" {
  m_aAttributes {
   ODIN_ToggleDamageEditorAttribute "{5964E09573BF5AE9}" {
    m_UIInfo SCR_EditorAttributeUIInfo "{5964E095742FEEF3}" {
@@ -8,9 +8,10 @@ SCR_EditorAttributeList {
    m_CategoryConfig "{8A757725BEAC5B36}Configs/Editor/AttributeCategories/Character.conf"
    m_Layout "{D0F3CE0C63A5AEBB}UI/layouts/Editor/Attributes/AttributePrefabs/AttributePrefab_Checkbox.layout"
   }
-  ODIN_ToggleDamageVehicleAttribute "{5DB0F3FD83111076}" {
-   m_UIInfo SCR_EditorAttributeUIInfo "{5DB0F3FD8108C6AB}" {
+  ODIN_ToggleDamageVehicleEditorAttribute "{5ED6C3A0F21F6245}" {
+   m_UIInfo SCR_EditorAttributeUIInfo "{5ED6C3A0FE983BF4}" {
     Name "#ODIN-Editor_Attribute_EnableDamage_Name"
+    m_cDescriptionIconColor 0.947 0.056 0.056 1
    }
    m_CategoryConfig "{7FA3F309CBFCDACF}Configs/Editor/AttributeCategories/Vehicle.conf"
    m_Layout "{D0F3CE0C63A5AEBB}UI/layouts/Editor/Attributes/AttributePrefabs/AttributePrefab_Checkbox.layout"

--- a/Scripts/Game/ODIN/Editor/Containers/Attributes/ODIN_ToggleDamageVehicleAttribute.c
+++ b/Scripts/Game/ODIN/Editor/Containers/Attributes/ODIN_ToggleDamageVehicleAttribute.c
@@ -2,7 +2,7 @@
 Entity Attribute for toggle damage on unit
 */
 [BaseContainerProps(), SCR_BaseEditorAttributeCustomTitle()]
-class ODIN_ToggleDamageVehicleAttribute : SCR_BaseEditorAttribute
+class ODIN_ToggleDamageVehicleEditorAttribute : SCR_BaseEditorAttribute
 {
 	override SCR_BaseEditorAttributeVar ReadVariable(Managed item, SCR_AttributesManagerEditorComponent manager)
 	{


### PR DESCRIPTION
- Renames `ODIN_ToggleDamageVehicleAttribute` to `ODIN_ToggleDamageVehicleEditorAttribute`
- Fixes the `edit.conf` file.