### PR TITLE
Prevent waypoint cycle from getting deleted when completed

### DIFF
--- a/Configs/Editor/ActionLists/Command/Command.conf
+++ b/Configs/Editor/ActionLists/Command/Command.conf
@@ -6,7 +6,7 @@ SCR_EditorActionList {
     Icon "{2373DD0E0D31AF81}UI/Textures/Editor/Toolbar/Commanding/Toolbar_Commanding_Waypoint_Cycle.edds"
    }
    m_ActionGroup COMMAND_WAYPOINT
-   m_CommandPrefab "{0FBDE34BE96FB7BA}PrefabsEditable/Auto/AI/Waypoints/E_AIWaypointCycle2.et"
+   m_CommandPrefab "{0FBDE34BE96FB7BA}PrefabsEditable/Auto/AI/Waypoints/E_AIWaypointCycle.et"
   }
  }
 }

--- a/Scripts/Game/ODIN/Editor/Components/EditableEntity/SCR_EditableGroupComponent.c
+++ b/Scripts/Game/ODIN/Editor/Components/EditableEntity/SCR_EditableGroupComponent.c
@@ -10,27 +10,35 @@ modded class SCR_EditableGroupComponent : SCR_EditableEntityComponent
 			
 		if (waypointCompToRemove && waypointCompToRemove.GetParentEntity() == this)
 		{
-			// Only delete if there is no waypoint cycle present
-			bool has_cycle = false;
-			array<AIWaypoint> waypoints = {};
-			m_Group.GetWaypoints(waypoints);
+			bool has_cycle = AIWaypointCycle.Cast(wp);
 			
-			foreach (AIWaypoint waypoint: waypoints)
-			{
+			if (!has_cycle)
+				has_cycle = ODIN_HasWaypointCycle();
 				
-				if (AIWaypointCycle.Cast(waypoint))
-				{
-					has_cycle = true;
-					waypointCompToRemove.setCompleted();
-					break;
-				};
-			};
+			// Only delete if there is no waypoint cycle present
 			if (!has_cycle)
 			{
 				waypointCompToRemove.Delete();
 			}
 		}
 		ReindexWaypoints();
+	}
+	
+	protected bool ODIN_HasWaypointCycle()
+	{
+		array<AIWaypoint> waypoints = {};
+		m_Group.GetWaypoints(waypoints);
+		
+		foreach (AIWaypoint waypoint : waypoints)
+		{
+				
+			if (AIWaypointCycle.Cast(waypoint))
+			{
+				return true;
+			};
+		};
+		
+		return false;
 	}
 	
 	override protected void OnWaypointAdded(AIWaypoint wp)


### PR DESCRIPTION
Completed waypoints trigger `OnWaypointRemoved`, which deletes the waypoint if some conditions are met. Checking whether the group has a cycle waypoint used to be enough for deciding whether the waypoint should be deleted. This is no longer the case, since `OnWaypointRemoved` now gets called before the cycle waypoint readds all waypoints.