### PR TITLE
Enable saving/loading sessions in MP for any PC client

### DIFF
--- a/Scripts/Game/ODIN/Editor/Containers/Actions/ToolbarActions/SCR_LoadSessionToolbarAction.c
+++ b/Scripts/Game/ODIN/Editor/Containers/Actions/ToolbarActions/SCR_LoadSessionToolbarAction.c
@@ -1,0 +1,24 @@
+[BaseContainerProps(), SCR_BaseContainerCustomTitleUIInfo("m_Info")]
+modded class SCR_LoadSessionToolbarAction : SCR_EditorToolbarAction
+{
+	//---------------------------------------------------------------------------------------------
+	//! Enable loading for clients on PC (disabled on Xbox, since broken)
+	override bool CanBeShown(SCR_EditableEntityComponent hoveredEntity, notnull set<SCR_EditableEntityComponent> selectedEntities, vector cursorWorldPosition, int flags)
+	{
+		//--- Disallow if editor save struct is not configured
+		SCR_SaveLoadComponent saveLoadComponent = SCR_SaveLoadComponent.GetInstance();
+		if (!saveLoadComponent || !saveLoadComponent.ContainsStruct(SCR_EditorStruct))
+			return false;
+		
+		if (Replication.IsServer())
+		{
+			//--- Loading is always available for the host and in singleplayer
+			return true;
+		}
+		else
+		{
+			//--- Loading is only available on PC in MP
+			return (System.GetPlatform() == EPlatform.WINDOWS);
+		}
+	}
+}

--- a/Scripts/Game/ODIN/Editor/Containers/Actions/ToolbarActions/SCR_SaveSessionToolbarAction.c
+++ b/Scripts/Game/ODIN/Editor/Containers/Actions/ToolbarActions/SCR_SaveSessionToolbarAction.c
@@ -1,0 +1,16 @@
+[BaseContainerProps(), SCR_BaseContainerCustomTitleUIInfo("m_Info")]
+modded class SCR_SaveSessionToolbarAction : SCR_EditorToolbarAction
+{
+	//---------------------------------------------------------------------------------------------
+	//! Enable saving for clients on PC (disabled on Xbox, since broken)
+	override bool CanBeShown(SCR_EditableEntityComponent hoveredEntity, notnull set<SCR_EditableEntityComponent> selectedEntities, vector cursorWorldPosition, int flags)
+	{
+		//--- Disallow on client if not PC, or in MP for "Save" version ("Save As" is allowed in MP)
+		if ((!Replication.IsServer() && System.GetPlatform() != EPlatform.WINDOWS) || (!m_bSaveAs && Replication.IsRunning()))
+			return false;
+		
+		//--- Disallow if editor save struct is not configured
+		SCR_SaveLoadComponent saveLoadComponent = SCR_SaveLoadComponent.GetInstance();
+		return saveLoadComponent && saveLoadComponent.ContainsStruct(SCR_EditorStruct);
+	}
+};


### PR DESCRIPTION
It seems that saving/loading sessions is fully MP compatible on PC, but got disabled for anyone, but the server host. This PR enables it for any PC client. It does not seem to work on Xbox though, so I disabled it there.